### PR TITLE
prefixed route id's with _

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -3,18 +3,18 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="dpn_xml_sitemap" pattern="/sitemap.xml">
+    <route id="_dpn_xml_sitemap" pattern="/sitemap.xml">
         <default key="_controller">dpn_xml_sitemap.controller:sitemapAction</default>
         <default key="_format">xml</default>
     </route>
 
-    <route id="dpn_xml_sitemap_number" pattern="/sitemap{number}.xml">
+    <route id="_dpn_xml_sitemap_number" pattern="/sitemap{number}.xml">
         <default key="_controller">dpn_xml_sitemap.controller:sitemapNumberAction</default>
         <default key="_format">xml</default>
         <requirement key="number">\d+</requirement>
     </route>
 
-    <route id="dpn_xml_sitemap_index" pattern="/sitemap_index.xml">
+    <route id="_dpn_xml_sitemap_index" pattern="/sitemap_index.xml">
         <default key="_controller">dpn_xml_sitemap.controller:sitemapIndexAction</default>
         <default key="_format">xml</default>
     </route>


### PR DESCRIPTION
When using the JMSI18nRoutingBundle, it creates /sitemap.xml routes for each locale.  This is not desirable.  It can be prevented by prefixing route id's with `_`.
