### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add DpnXmlSitemapBundle in your composer.json:
 ```json
 {
     "require": {
-        "dpn/xml-sitemap-bundle": "*"
+        "dpn/xml-sitemap-bundle": "dev-master"
     }
 }
 ```


### PR DESCRIPTION
the "*" match the last available release of the repo, which is for now the 1.1 branch, (= the 1.1.1 tag). Since various important issues were fixed in the dev-master (by example: only the dev-master in compatible with the stable release of Sonata Page), & if you do not plan to release a new branch in the next few days, I suggest to change the package version in the install documentation.
